### PR TITLE
ParseTemplate: First grep from file and than replace strings with sed…

### DIFF
--- a/modules/.sharedfunctions
+++ b/modules/.sharedfunctions
@@ -7,7 +7,7 @@
 # This file defines some standard functions for use in ProxyManager modules
 
 ParseTemplate() {
-    grep -v "^#" | sed 's/PMHOSTTAG/'${PM_PROXY_HOST}'/g; s/PMPORTTAG/'${PM_PROXY_PORT}'/g' $1
+    grep -v "^#" $1 | sed 's/PMHOSTTAG/'${PM_PROXY_HOST}'/g; s/PMPORTTAG/'${PM_PROXY_PORT}'/g'
 }
 
 # Future function that will likely be useful in several modules, 


### PR DESCRIPTION
…. Previous function does not work using grep 2.16 and sed 4.2.2 on Ubuntu 14.04