### PR TITLE
Set and unset https instead of git protocol.

### DIFF
--- a/modules/curlrc
+++ b/modules/curlrc
@@ -25,9 +25,9 @@ case "$1" in
     if [ -f $CURL_CF ]
     then
        grep -v "^[^#]*proxy =" $CURL_CF > $TEMPFILE
-       ParseTemplate $PM_INSTALL_DIR/templates/enable_curl >> $TEMPFILE
-       cp $TEMPFILE $CURL_CF
     fi
+    ParseTemplate $PM_INSTALL_DIR/templates/enable_curl >> $TEMPFILE
+    cp $TEMPFILE $CURL_CF
     ;;
   off)
     echo Disabling for Curl

--- a/modules/git
+++ b/modules/git
@@ -16,11 +16,13 @@ case "$1" in
     echo Enabling for Git global
     which git > /dev/null || exit
     git config --global http.proxy http://${PM_PROXY_HOST}:${PM_PROXY_PORT}
+    git config --global url."https://".insteadOf git://
     ;;
   off)
     echo Disabling for Git global
     which git > /dev/null || exit
-    git config --global http.proxy ""
+    git config --global --unset http.proxy http://${PM_PROXY_HOST}:${PM_PROXY_PORT}
+    git config --global --unset url."https://".insteadOf git://
     ;;
   check*)
     if ! which git > /dev/null


### PR DESCRIPTION
Most of the proxies do not allow the dedicated port (9418), using https instead does not need another port. But it doesn't work, if only git protocol is allowed by the server and there is no https option ... then you may need something to tunnel the port.
