### PR TITLE
Enable proxy in curl even if ~/.curlrc doesn't exist before

### DIFF
--- a/modules/curlrc
+++ b/modules/curlrc
@@ -22,12 +22,13 @@ GetUniqueTempFile curlrc
 case "$1" in
   on)
     echo Enabling for Curl
-    if [ -f $CURL_CF ]
+    if [ ! -f $CURL_CF ]
     then
-       grep -v "^[^#]*proxy =" $CURL_CF > $TEMPFILE
-       ParseTemplate $PM_INSTALL_DIR/templates/enable_curl >> $TEMPFILE
-       cp $TEMPFILE $CURL_CF
+      touch $CURL_CF
     fi
+    grep -v "^[^#]*proxy =" $CURL_CF > $TEMPFILE
+    ParseTemplate $PM_INSTALL_DIR/templates/enable_curl >> $TEMPFILE
+    cp $TEMPFILE $CURL_CF
     ;;
   off)
     echo Disabling for Curl


### PR DESCRIPTION
You check, if there is no file, but don't create it on enable. Installation of curl does not create it by default and the scripts can not enable it again, if file was deleted. thx
